### PR TITLE
[1.28 backport] pilot: watch meshConfig in remote clusters (#58455)

### DIFF
--- a/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
+++ b/manifests/charts/istio-control/istio-discovery/templates/reader-clusterrole.yaml
@@ -22,7 +22,7 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list" ]

--- a/pilot/pkg/serviceregistry/aggregate/controller.go
+++ b/pilot/pkg/serviceregistry/aggregate/controller.go
@@ -378,6 +378,12 @@ func mergeService(dst, src *model.Service, srcRegistry serviceregistry.Instance)
 		newAddresses := src.ClusterVIPs.GetAddressesFor(clusterID)
 		dst.ClusterVIPs.SetAddressesFor(clusterID, newAddresses)
 	}
+	// Merge service accounts from different clusters
+	// Each cluster may have a different trust domain, so we need to collect all unique service accounts
+	if len(src.ServiceAccounts) > 0 {
+		dst.ServiceAccounts = append(dst.ServiceAccounts, src.ServiceAccounts...)
+		dst.ServiceAccounts = slices.FilterDuplicates(dst.ServiceAccounts)
+	}
 }
 
 // NetworkGateways merges the service-based cross-network gateways from each registry.

--- a/pilot/pkg/serviceregistry/kube/controller/controller.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller.go
@@ -233,7 +233,7 @@ type Controller struct {
 
 	// initialSyncTimedout is set to true after performing an initial processing timed out.
 	initialSyncTimedout *atomic.Bool
-	meshWatcher         mesh.Watcher
+	meshWatcher         mesh.RestrictedConfigWatcher
 
 	podsClient kclient.Client[*v1.Pod]
 
@@ -329,7 +329,7 @@ func NewController(kubeClient kubelib.Client, options Options) *Controller {
 	c.exports = newServiceExportCache(c)
 	c.imports = newServiceImportCache(c)
 
-	c.meshWatcher = options.MeshWatcher
+	c.meshWatcher = mesh.NewRestrictedConfigWatcher(options.MeshWatcher)
 	if c.opts.MeshNetworksWatcher != nil {
 		c.networksHandlerRegistration = c.opts.MeshNetworksWatcher.AddNetworksHandler(func() {
 			c.reloadMeshNetworks()
@@ -418,7 +418,7 @@ func (c *Controller) onServiceEvent(pre, curr *v1.Service, event model.Event) er
 	log.Debugf("Handle event %s for service %s in namespace %s", event, curr.Name, curr.Namespace)
 
 	// Create the standard (cluster.local) service.
-	svcConv := kube.ConvertService(*curr, c.opts.DomainSuffix, c.Cluster(), c.meshWatcher.Mesh())
+	svcConv := kube.ConvertService(*curr, c.opts.DomainSuffix, c.Cluster(), c.meshWatcher.TrustDomain())
 
 	switch event {
 	case model.EventDelete:

--- a/pilot/pkg/serviceregistry/kube/controller/controller_test.go
+++ b/pilot/pkg/serviceregistry/kube/controller/controller_test.go
@@ -2800,16 +2800,16 @@ func TestServiceUpdateNeedsPush(t *testing.T) {
 			name:     "target ports changed",
 			prev:     &svc,
 			curr:     &updatedSvc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
-			currConv: kube.ConvertService(updatedSvc, constants.DefaultClusterLocalDomain, "", nil),
+			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
+			currConv: kube.ConvertService(updatedSvc, constants.DefaultClusterLocalDomain, "", ""),
 			expect:   true,
 		},
 		testcase{
 			name:     "target ports unchanged",
 			prev:     &svc,
 			curr:     &svc,
-			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
-			currConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", nil),
+			prevConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
+			currConv: kube.ConvertService(svc, constants.DefaultClusterLocalDomain, "", ""),
 			expect:   false,
 		})
 

--- a/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
+++ b/pilot/pkg/serviceregistry/kube/controller/endpoint_builder.go
@@ -52,7 +52,7 @@ func (c *Controller) NewEndpointBuilder(pod *v1.Pod) *EndpointBuilder {
 	var podLabels labels.Instance
 	if pod != nil {
 		locality = c.getPodLocality(pod)
-		sa = kube.SecureNamingSAN(pod, c.meshWatcher.Mesh())
+		sa = kube.SecureNamingSAN(pod, c.meshWatcher.TrustDomain())
 		podLabels = pod.Labels
 		namespace = pod.Namespace
 		subdomain = pod.Spec.Subdomain

--- a/pilot/pkg/serviceregistry/kube/controller/multicluster.go
+++ b/pilot/pkg/serviceregistry/kube/controller/multicluster.go
@@ -33,9 +33,12 @@ import (
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pilot/pkg/serviceregistry/serviceentry"
 	"istio.io/istio/pkg/backoff"
+	"istio.io/istio/pkg/config/mesh/kubemesh"
+	"istio.io/istio/pkg/config/mesh/meshwatcher"
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	kubelib "istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/multicluster"
 	"istio.io/istio/pkg/webhooks"
 )
@@ -123,6 +126,26 @@ func NewMulticluster(
 		}
 		log.Infof("Initializing Kubernetes service registry %q", options.ClusterID)
 		options.ConfigCluster = configCluster
+
+		// Create per-cluster mesh watcher for remote clusters
+		// This allows controllers to detect cluster-specific settings that may be relevant for the local proxies, e.g. trust domain.
+		if !configCluster {
+			meshConfigMapName := mc.getMeshConfigMapName()
+			meshSource := kubemesh.NewConfigMapSource(
+				client,
+				options.SystemNamespace,
+				meshConfigMapName,
+				kubemesh.MeshConfigKey,
+				krt.NewOptionsBuilder(stop, "", nil),
+			)
+			remoteMeshCollection := meshwatcher.NewCollection(
+				krt.NewOptionsBuilder(stop, "", nil),
+				meshSource,
+			)
+			options.MeshWatcher = meshwatcher.ConfigAdapter(remoteMeshCollection)
+			log.Infof("Created mesh watcher for remote cluster %q", cluster.ID)
+		}
+
 		kubeRegistry := NewController(client, options)
 		kubeController := &kubeController{
 			MeshServiceController: opts.MeshServiceController,
@@ -134,6 +157,15 @@ func NewMulticluster(
 	})
 
 	return mc
+}
+
+// getMeshConfigMapName returns the mesh ConfigMap name based on the revision
+func (m *Multicluster) getMeshConfigMapName() string {
+	name := "istio"
+	if m.revision == "" || m.revision == "default" {
+		return name
+	}
+	return name + "-" + m.revision
 }
 
 // initializeCluster initializes the cluster by setting various handlers.

--- a/pilot/pkg/serviceregistry/kube/conversion.go
+++ b/pilot/pkg/serviceregistry/kube/conversion.go
@@ -25,7 +25,6 @@ import (
 
 	"istio.io/api/annotation"
 	"istio.io/api/label"
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pilot/pkg/model"
 	"istio.io/istio/pilot/pkg/serviceregistry/provider"
 	"istio.io/istio/pkg/cluster"
@@ -45,7 +44,7 @@ func convertPort(port corev1.ServicePort) *model.Port {
 	}
 }
 
-func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.ID, mesh *meshconfig.MeshConfig) *model.Service {
+func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.ID, trustDomain string) *model.Service {
 	addrs := []string{constants.UnspecifiedIP}
 	resolution := model.ClientSideLB
 	externalName := ""
@@ -80,7 +79,7 @@ func ConvertService(svc corev1.Service, domainSuffix string, clusterID cluster.I
 	}
 	if svc.Annotations[annotation.AlphaKubernetesServiceAccounts.Name] != "" {
 		for _, ksa := range strings.Split(svc.Annotations[annotation.AlphaKubernetesServiceAccounts.Name], ",") {
-			serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace, mesh))
+			serviceaccounts = append(serviceaccounts, kubeToIstioServiceAccount(ksa, svc.Namespace, trustDomain))
 		}
 	}
 	if svc.Annotations[annotation.NetworkingExportTo.Name] != "" {
@@ -179,13 +178,13 @@ func ServiceHostnameForKR(obj metav1.Object, domainSuffix string) host.Name {
 }
 
 // kubeToIstioServiceAccount converts a K8s service account to an Istio service account
-func kubeToIstioServiceAccount(saname string, ns string, mesh *meshconfig.MeshConfig) string {
-	return spiffe.MustGenSpiffeURI(mesh, ns, saname)
+func kubeToIstioServiceAccount(saname string, ns string, trustDomain string) string {
+	return spiffe.MustGenSpiffeURIForTrustDomain(trustDomain, ns, saname)
 }
 
 // SecureNamingSAN creates the secure naming used for SAN verification from pod metadata
-func SecureNamingSAN(pod *corev1.Pod, mesh *meshconfig.MeshConfig) string {
-	return spiffe.MustGenSpiffeURI(mesh, pod.Namespace, pod.Spec.ServiceAccountName)
+func SecureNamingSAN(pod *corev1.Pod, trustDomain string) string {
+	return spiffe.MustGenSpiffeURIForTrustDomain(trustDomain, pod.Namespace, pod.Spec.ServiceAccountName)
 }
 
 // PodTLSMode returns the tls mode associated with the pod if pod has been injected with sidecar

--- a/pilot/pkg/serviceregistry/kube/conversion_test.go
+++ b/pilot/pkg/serviceregistry/kube/conversion_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"istio.io/api/annotation"
-	meshconfig "istio.io/api/mesh/v1alpha1"
 	"istio.io/istio/pkg/cluster"
 	"istio.io/istio/pkg/config/kube"
 	"istio.io/istio/pkg/config/protocol"
@@ -169,7 +168,7 @@ func TestServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(localSvc, domainSuffix, clusterID, &meshconfig.MeshConfig{TrustDomain: domainSuffix})
+	service := ConvertService(localSvc, domainSuffix, clusterID, domainSuffix)
 	if service == nil {
 		t.Fatal("could not convert service")
 	}
@@ -255,7 +254,7 @@ func TestServiceConversionWithEmptyServiceAccountsAnnotation(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(localSvc, domainSuffix, clusterID, nil)
+	service := ConvertService(localSvc, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert service")
 	}
@@ -310,7 +309,7 @@ func TestServiceConversionWithExportToAnnotation(t *testing.T) {
 	}
 	for _, test := range tests {
 		localSvc.Annotations[annotation.NetworkingExportTo.Name] = test.Annotation
-		service := ConvertService(localSvc, domainSuffix, clusterID, nil)
+		service := ConvertService(localSvc, domainSuffix, clusterID, "")
 		if service == nil {
 			t.Fatal("could not convert service")
 		}
@@ -343,7 +342,7 @@ func TestExternalServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, nil)
+	service := ConvertService(extSvc, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -393,7 +392,7 @@ func TestExternalClusterLocalServiceConversion(t *testing.T) {
 
 	domainSuffix := "cluster.local"
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, nil)
+	service := ConvertService(extSvc, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -454,7 +453,7 @@ func TestLBServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(extSvc, domainSuffix, clusterID, nil)
+	service := ConvertService(extSvc, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert external service")
 	}
@@ -500,7 +499,7 @@ func TestInternalTrafficPolicyServiceConversion(t *testing.T) {
 		},
 	}
 
-	service := ConvertService(svc, domainSuffix, clusterID, nil)
+	service := ConvertService(svc, domainSuffix, clusterID, "")
 	if service == nil {
 		t.Fatal("could not convert service")
 	}
@@ -520,9 +519,7 @@ func TestSecureNamingSAN(t *testing.T) {
 	pod.Namespace = ns
 	pod.Spec.ServiceAccountName = sa
 
-	mesh := &meshconfig.MeshConfig{TrustDomain: "td.local"}
-
-	san := SecureNamingSAN(pod, mesh)
+	san := SecureNamingSAN(pod, "td.local")
 
 	expectedSAN := fmt.Sprintf("spiffe://td.local/ns/%v/sa/%v", ns, sa)
 

--- a/pkg/config/mesh/meshwatcher/watcher_test_utils.go
+++ b/pkg/config/mesh/meshwatcher/watcher_test_utils.go
@@ -20,6 +20,8 @@ import (
 	"istio.io/istio/pkg/kube/krt"
 )
 
+var _ mesh.RestrictedConfigWatcher = &TestWatcher{}
+
 // TestWatcher provides an interface that takes a static MeshConfig which can be updated explicitly.
 // It is intended for tests
 type TestWatcher struct {
@@ -29,6 +31,14 @@ type TestWatcher struct {
 
 func (w TestWatcher) Set(n *meshconfig.MeshConfig) {
 	w.col.Set(&MeshConfigResource{n})
+}
+
+func (w TestWatcher) TrustDomain() string {
+	return w.Mesh().GetTrustDomain()
+}
+
+func (w TestWatcher) ServiceScopeConfigs() []*meshconfig.MeshConfig_ServiceScopeConfigs {
+	return w.Mesh().GetServiceScopeConfigs()
 }
 
 // NewTestWatcher creates a new Watcher that always returns the given mesh config.

--- a/pkg/config/mesh/watchers.go
+++ b/pkg/config/mesh/watchers.go
@@ -57,3 +57,29 @@ func NewWatcherHandlerRegistration(f func()) *WatcherHandlerRegistration {
 func (r *WatcherHandlerRegistration) Remove() {
 	r.remove()
 }
+
+// RestrictedConfigWatcher provides limited access to mesh configuration.
+// It exposes only trust domain and service scope, suitable for use in remote clusters
+// or components that should not have full mesh config access.
+type RestrictedConfigWatcher interface {
+	TrustDomain() string
+	ServiceScopeConfigs() []*v1alpha1.MeshConfig_ServiceScopeConfigs
+}
+
+// NewRestrictedConfigWatcher wraps a Holder to expose only trust domain and service scope.
+func NewRestrictedConfigWatcher(holder Holder) RestrictedConfigWatcher {
+	return restrictedConfigAdapter{holder}
+}
+
+// restrictedConfigAdapter wraps a Holder to provide RestrictedConfigWatcher interface.
+type restrictedConfigAdapter struct {
+	Holder
+}
+
+func (r restrictedConfigAdapter) TrustDomain() string {
+	return r.Mesh().GetTrustDomain()
+}
+
+func (r restrictedConfigAdapter) ServiceScopeConfigs() []*v1alpha1.MeshConfig_ServiceScopeConfigs {
+	return r.Mesh().GetServiceScopeConfigs()
+}

--- a/releasenotes/notes/watch-remote-mesh-config.yaml
+++ b/releasenotes/notes/watch-remote-mesh-config.yaml
@@ -1,0 +1,9 @@
+apiVersion: release-notes/v2
+kind: feature
+area: security
+
+releaseNotes:
+- |
+  **Improved** remote cluster trust domain handling by implementing watching of remote `meshConfig`.
+  Istiod now automatically watches and updates trust domain information from remote clusters,
+  ensuring accurate SAN matching for services, which belong to more than one trust domain.


### PR DESCRIPTION
* Add missing permission for watching remote configmaps



* Implement watching remote trust domain



* Add a release note



* Implement restricted mesh watcher



* Make TestWatcher an impl of RestrictedConfigWatcher



---------


(cherry picked from commit 2ece87e917c9a35c184495320dc5235d8928f042)

**Please provide a description of this PR:**



**To help us figure out who should review this PR, please put an X in all the areas that this PR affects.**

- [ ] Ambient
- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Dual Stack
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Upgrade
- [ ] Multi Cluster
- [ ] Virtual Machine
- [ ] Control Plane Revisions

**Please check any characteristics that apply to this pull request.**

- [ ] Does not have any [user-facing](https://github.com/istio/istio/tree/master/releasenotes#when-to-add-release-notes) changes. This may include CLI changes, API changes, behavior changes, performance improvements, etc.
